### PR TITLE
add in graph global approvals

### DIFF
--- a/app/[contractAddress]/[tokenId]/[chainId]/TokenDetail.tsx
+++ b/app/[contractAddress]/[tokenId]/[chainId]/TokenDetail.tsx
@@ -26,7 +26,7 @@ const iconVariant = {
     transition: { duration: 0.3, ease: "easeInOut" },
   },
   unHovered: {
-    opacity: 0.3,
+    opacity: 0.7,
     boxShadow: "none",
     transition: { duration: 0.3, ease: "easeInOut" },
   },

--- a/app/[contractAddress]/[tokenId]/[chainId]/page.tsx
+++ b/app/[contractAddress]/[tokenId]/[chainId]/page.tsx
@@ -110,32 +110,21 @@ export default function Token({ params, searchParams }: TokenParams) {
   const [tokens, setTokens] = useState<TbaOwnedNft[]>([]);
   const allNfts = [...nfts, ...lensNfts];
 
-  const { data: approvalData } = useGetApprovals(
-    allNfts.map((nft) => nft.contract.address),
-    account
-  );
+  const { data: approvalData } = useGetApprovals(allNfts, account, chainIdNumber);
 
   useEffect(() => {
     if (nfts !== undefined && nfts.length) {
       nfts.map((token) => {
-        const foundApproval = approvalData?.find((item: any) => {
-          const contract = item?.value?.contract;
-          const tokenIds = item?.approvedTokenIds;
-          const approvalForAll = item.nftApprovalForAll;
-
-          if (getAddress(contract) === getAddress(token.contract.address) && approvalForAll) {
-            return true;
-          }
-
-          if (
-            getAddress(contract) === getAddress(token.contract.address) &&
-            tokenIds &&
-            tokenIds.includes(String(token.tokenId))
-          ) {
+        const foundApproval = approvalData?.find((item) => {
+          const contract = item.contract.address;
+          const tokenId = item.tokenId;
+          const hasApprovals = item.hasApprovals;
+          const matchedAddress = getAddress(contract) === getAddress(token.contract.address);
+          const matchedTokenId = String(tokenId) && String(token.tokenId);
+          if (matchedAddress && matchedTokenId && hasApprovals) {
             return true;
           }
         });
-
         token.hasApprovals = foundApproval?.hasApprovals || false;
       });
       setTokens(nfts);
@@ -153,7 +142,7 @@ export default function Token({ params, searchParams }: TokenParams) {
             <TokenDetail
               isOpen={showTokenDetail}
               handleOpenClose={setShowTokenDetail}
-              approvalTokensCount={approvalData?.length}
+              approvalTokensCount={approvalData?.filter((item) => item.hasApprovals).length}
               account={account}
               tokens={tokens}
               title={nftMetadata.title}

--- a/app/[contractAddress]/[tokenId]/page.tsx
+++ b/app/[contractAddress]/[tokenId]/page.tsx
@@ -112,32 +112,21 @@ export default function Token({ params, searchParams }: TokenParams) {
 
   const allNfts = [...nfts, ...lensNfts];
 
-  const { data: approvalData } = useGetApprovals(
-    allNfts.map((nft) => nft.contract.address),
-    account
-  );
+  const { data: approvalData } = useGetApprovals(allNfts, account);
 
   useEffect(() => {
     if (nfts !== undefined && nfts.length) {
       nfts.map((token) => {
-        const foundApproval = approvalData?.find((item: any) => {
-          const contract = item?.value?.contract;
-          const tokenIds = item?.approvedTokenIds;
-          const approvalForAll = item.nftApprovalForAll;
-
-          if (getAddress(contract) === getAddress(token.contract.address) && approvalForAll) {
-            return true;
-          }
-
-          if (
-            getAddress(contract) === getAddress(token.contract.address) &&
-            tokenIds &&
-            tokenIds.includes(String(token.tokenId))
-          ) {
+        const foundApproval = approvalData?.find((item) => {
+          const contract = item.contract.address;
+          const tokenId = item.tokenId;
+          const hasApprovals = item.hasApprovals;
+          const matchedAddress = getAddress(contract) === getAddress(token.contract.address);
+          const matchedTokenId = String(tokenId) && String(token.tokenId);
+          if (matchedAddress && matchedTokenId && hasApprovals) {
             return true;
           }
         });
-
         token.hasApprovals = foundApproval?.hasApprovals || false;
       });
       setTokens(nfts);

--- a/app/[contractAddress]/[tokenId]/page.tsx
+++ b/app/[contractAddress]/[tokenId]/page.tsx
@@ -144,7 +144,7 @@ export default function Token({ params, searchParams }: TokenParams) {
             <TokenDetail
               isOpen={showTokenDetail}
               handleOpenClose={setShowTokenDetail}
-              approvalTokensCount={approvalData?.length}
+              approvalTokensCount={approvalData?.filter((item) => item.hasApprovals).length}
               account={account}
               tokens={tokens}
               title={nftMetadata.title}

--- a/lib/constants/apiKeys.ts
+++ b/lib/constants/apiKeys.ts
@@ -1,1 +1,2 @@
 export const nxyzApiKey = process.env.NEXT_PUBLIC_NXYZ_API_KEY || "";
+export const graphApiKey = process.env.NEXT_PUBLIC_GRAPH_API_KEY || "";

--- a/lib/hooks/useGetApprovals.ts
+++ b/lib/hooks/useGetApprovals.ts
@@ -1,21 +1,235 @@
+import { OwnedNft } from "alchemy-sdk";
+import { erc721Abi } from "@/lib/abi";
+import { getPublicClient } from "@/lib/clients";
 import useSWR from "swr";
-import { nxyzApiKey, nxyzUrl } from "@/lib/constants";
+import { graphApiKey } from "@/lib/constants";
+import request from "graphql-request";
 
-export const useGetApprovals = (contracts: string[], owner?: string, chainID = "ethereum") => {
-  const contractsString = contracts.join(",");
-  const encodedContracts = encodeURIComponent(contractsString);
-  const apiUrl = `${nxyzUrl}/address/${owner}/allowances?chainID=${chainID}&contractAddresses=${encodedContracts}&apikey=${nxyzApiKey}`;
-  const ignoreFetch = !owner || !contracts || contracts.length === 0;
+export const useGetApprovals = (ownedNfts: OwnedNft[], owner?: string, chainID = 1) => {
+  const contractsString = ownedNfts?.map((item) => item.contract.address).join(",");
+  const ignoreFetch = !owner || ownedNfts.length === 0;
 
-  return useSWR(ignoreFetch ? null : apiUrl, async (url) => {
-    const response = await fetch(url, {
-      headers: {
-        accept: "application/json",
-      },
+  return useSWR(
+    ignoreFetch ? null : `${owner}/${chainID}&contractAddresses=${contractsString}`,
+    async () => {
+      const response = await handleNftApprovals(ownedNfts, owner as string, chainID);
+
+      return response;
+    }
+  );
+};
+
+export interface Nft extends OwnedNft {
+  hasApprovals?: boolean;
+}
+
+function checkGlobalApproval(approvals: { approved: boolean }[]) {
+  return approvals.reduce((result, item) => {
+    return result || item.approved;
+  }, false);
+}
+
+interface GetApproved {
+  data?: boolean;
+  error?: string;
+}
+
+export async function getApproved(
+  account: string,
+  tokenId: number,
+  chainId: number
+): Promise<GetApproved> {
+  try {
+    const publicClient = getPublicClient(chainId);
+    const response = (await publicClient.readContract({
+      address: account as `0x${string}`,
+      abi: erc721Abi,
+      functionName: "getApproved",
+      args: [tokenId],
+    })) as string;
+
+    return { data: response !== "0x0000000000000000000000000000000000000000" };
+  } catch (error) {
+    console.error(error);
+    return {
+      error: `Failed to get approval for token id: ${tokenId}, ${account}.`,
+    };
+  }
+}
+
+export async function getERC721ApprovedOperators(
+  contractAddress: string,
+  ownerAddress: string
+): Promise<any> {
+  const subgraphUrl = `https://gateway.thegraph.com/api/${graphApiKey}/subgraphs/id/AVZ1dGwmRGKsbDAbwvxNmXzeEkD48voB3LfGqj5w7FUS`;
+  const query = `
+    {
+      erc721Operators(where:{contract:"${contractAddress}" owner:"${ownerAddress}"}) {
+        approved
+      }
+    }
+  `;
+
+  try {
+    const response = await request(subgraphUrl, query);
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw new Error("Failed to fetch approved operators from subgraph");
+  }
+}
+
+export async function getERC1155ApprovedOperators(
+  contractAddress: string,
+  ownerAddress: string
+): Promise<any> {
+  const subgraphUrl = `https://gateway.thegraph.com/api/${graphApiKey}/subgraphs/id/GCQVLurkeZrdMf4t5v5NyeWJY8pHhfE9sinjFMjLYd9C`;
+  const query = `
+    {
+      erc1155Operators(
+        where:{
+          contract:"${contractAddress}"
+          owner:"${ownerAddress}"
+        }
+      ) {
+        approved
+      }
+    }
+  `;
+
+  try {
+    const response = await request(subgraphUrl, query);
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw new Error("Failed to fetch approved operators from subgraph");
+  }
+}
+
+interface GetGlobalApprovalsForContractsReturn {
+  data: { [contract: string]: boolean };
+  error?: string;
+}
+
+export async function getGlobalApprovalsForContracts(
+  contracts: { address: string; tokenType: "ERC721" | "ERC1155" }[],
+  ownerAddress: string
+): Promise<GetGlobalApprovalsForContractsReturn> {
+  try {
+    const promises = await Promise.all(
+      contracts.map((contract) => {
+        if (contract.tokenType === "ERC721") {
+          return getERC721ApprovedOperators(contract.address, ownerAddress);
+        }
+
+        return getERC1155ApprovedOperators(contract.address, ownerAddress);
+      })
+    );
+
+    const data = promises.reduce((a, b, i) => {
+      if (b.erc721Operators) {
+        const hasGlobalApprovals = checkGlobalApproval(b.erc721Operators);
+        a[contracts[i].address] = hasGlobalApprovals;
+      }
+
+      if (b.erc1155Operators) {
+        const hasGlobalApprovals = checkGlobalApproval(b.erc1155Operators);
+        a[contracts[i].address] = hasGlobalApprovals;
+      }
+
+      return a;
+    }, {} as { [contract: string]: boolean });
+
+    return { data };
+  } catch (err) {
+    console.error(err);
+
+    return {
+      error: "Failed to fetch global approvals for contracts",
+      data: {},
+    };
+  }
+}
+
+export async function handleNftApprovals(nfts: OwnedNft[], account: string, chainId: number) {
+  try {
+    // create a map of contracts from nfts
+    const contracts = nfts.reduce((a, nft) => {
+      const contractAddress = nft.contract.address;
+
+      if (!a[contractAddress]) {
+        a[contractAddress] = {
+          address: contractAddress,
+          tokenType: nft.contract.tokenType as "ERC721" | "ERC1155",
+        };
+      }
+
+      return a;
+    }, {} as { [contract: string]: { address: string; tokenType: "ERC721" | "ERC1155" } });
+
+    // fetch global approvals for all nft contracts
+    const { data: globalContractApprovalsMap, error: globalApprovalError } =
+      await getGlobalApprovalsForContracts(Object.values(contracts), account);
+
+    if (globalApprovalError) {
+      console.error(globalApprovalError);
+      return [];
+    }
+
+    const erc721Nfts = nfts.filter((nft) => nft.contract.tokenType === "ERC721");
+    const erc1155Nfts = nfts.filter((nft) => nft.contract.tokenType === "ERC1155");
+
+    const nftsToGetTokenApprovals: Nft[] = [];
+    const erc721NftsWithGlobalApprovals: Nft[] = [];
+
+    erc721Nfts.forEach((nft) => {
+      const hasApprovals = globalContractApprovalsMap[nft.contract.address];
+
+      if (hasApprovals) {
+        erc721NftsWithGlobalApprovals.push({ ...nft, hasApprovals });
+        return;
+      }
+
+      nftsToGetTokenApprovals.push(nft);
+      return;
     });
 
-    const headers = response.headers.get("Content-Type");
+    const approvals = await Promise.all(
+      nftsToGetTokenApprovals.map((nft) =>
+        getApproved(nft.contract.address, Number(nft.tokenId), chainId)
+      )
+    );
 
-    return await response.json();
-  });
-};
+    const erc721NftsTokenApprovals = nftsToGetTokenApprovals.map((nft, i) => ({
+      ...nft,
+      hasApprovals: approvals[i].data ?? false,
+    }));
+
+    const erc1155NftsWithApprovalCheck = erc1155Nfts.map((nft) => ({
+      ...nft,
+      hasApprovals: !!globalContractApprovalsMap[nft.contract.address],
+    }));
+
+    return [
+      ...erc721NftsWithGlobalApprovals.map((nft) => ({
+        contract: nft.contract,
+        tokenId: nft.tokenId,
+        hasApprovals: nft.hasApprovals,
+      })),
+      ...erc721NftsTokenApprovals.map((nft) => ({
+        contract: nft.contract,
+        tokenId: nft.tokenId,
+        hasApprovals: nft.hasApprovals,
+      })),
+      ...erc1155NftsWithApprovalCheck.map((nft) => ({
+        contract: nft.contract,
+        tokenId: nft.tokenId,
+        hasApprovals: nft.hasApprovals,
+      })),
+    ];
+  } catch (err) {
+    console.error(err);
+
+    return [];
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-polymorphic-types": "^2.0.0",
+    "request": "^2.88.2",
     "swr": "^2.1.5",
     "typescript": "5.1.3",
     "viem": "^1.0.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   react-polymorphic-types:
     specifier: ^2.0.0
     version: 2.0.0(@types/react@18.2.12)
+  request:
+    specifier: ^2.88.2
+    version: 2.88.2
   swr:
     specifier: ^2.1.5
     version: 2.1.5(react@18.2.0)
@@ -1192,8 +1195,23 @@ packages:
       get-intrinsic: 1.2.1
     dev: false
 
+  /asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+    dev: false
+
   /ast-types-flow@0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
+    dev: false
+
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: false
 
   /autoprefixer@10.4.14(postcss@8.4.24):
@@ -1217,6 +1235,14 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
+  /aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+    dev: false
+
+  /aws4@1.12.0:
+    resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
+    dev: false
+
   /axe-core@4.7.2:
     resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==}
     engines: {node: '>=4'}
@@ -1238,6 +1264,12 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+    dependencies:
+      tweetnacl: 0.14.5
+    dev: false
 
   /bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
@@ -1343,6 +1375,10 @@ packages:
   /caniuse-lite@1.0.30001503:
     resolution: {integrity: sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==}
 
+  /caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+    dev: false
+
   /chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
     engines: {node: '>=8'}
@@ -1394,6 +1430,13 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: false
 
+  /combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
+
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1409,6 +1452,10 @@ packages:
   /cookie@0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
     dev: false
 
   /cross-fetch@3.1.6(encoding@0.1.13):
@@ -1447,6 +1494,13 @@ packages:
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+    dev: false
+
+  /dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      assert-plus: 1.0.0
     dev: false
 
   /debug@2.6.9:
@@ -1518,6 +1572,11 @@ packages:
       object-keys: 1.1.1
     dev: false
 
+  /delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1550,6 +1609,13 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
+    dev: false
+
+  /ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
     dev: false
 
   /electron-to-chromium@1.4.430:
@@ -2036,6 +2102,15 @@ packages:
       type: 2.7.2
     dev: false
 
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
+  /extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
@@ -2110,6 +2185,19 @@ packages:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.7
+    dev: false
+
+  /forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+    dev: false
+
+  /form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
     dev: false
 
   /fraction.js@4.2.0:
@@ -2187,6 +2275,12 @@ packages:
     resolution: {integrity: sha512-lgbo68hHTQnFddybKbbs/RDRJnJT5YyGy2kQzVwbq+g67X73i+5MVTval34QxGkOe9X5Ujf1UYpCaphLyltjEg==}
     dependencies:
       resolve-pkg-maps: 1.0.0
+    dev: false
+
+  /getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+    dependencies:
+      assert-plus: 1.0.0
     dev: false
 
   /glob-parent@5.1.2:
@@ -2317,6 +2411,20 @@ packages:
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: false
 
+  /har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
+    dev: false
+
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
     dev: false
@@ -2374,6 +2482,15 @@ packages:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
       react-is: 16.13.1
+    dev: false
+
+  /http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.17.0
     dev: false
 
   /https-proxy-agent@5.0.1:
@@ -2623,6 +2740,10 @@ packages:
       ws: 8.12.0
     dev: false
 
+  /isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+    dev: false
+
   /jiti@1.18.2:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
@@ -2643,12 +2764,24 @@ packages:
       argparse: 2.0.1
     dev: false
 
+  /jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+    dev: false
+
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: false
 
+  /json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: false
+
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    dev: false
+
+  /json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: false
 
   /json5@1.0.2:
@@ -2656,6 +2789,16 @@ packages:
     hasBin: true
     dependencies:
       minimist: 1.2.8
+    dev: false
+
+  /jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
     dev: false
 
   /jsx-ast-utils@3.3.3:
@@ -2759,6 +2902,18 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
+
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -2923,6 +3078,10 @@ packages:
       path-key: 4.0.0
     dev: false
 
+  /oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3072,6 +3231,10 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+    dev: false
+
+  /performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
     dev: false
 
   /picocolors@1.0.0:
@@ -3253,9 +3416,18 @@ packages:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: false
 
+  /psl@1.9.0:
+    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    dev: false
+
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
+    dev: false
+
+  /qs@6.5.3:
+    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+    engines: {node: '>=0.6'}
     dev: false
 
   /queue-microtask@1.2.3:
@@ -3316,6 +3488,33 @@ packages:
       functions-have-names: 1.2.3
     dev: false
 
+  /request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.12.0
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.3
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+    dev: false
+
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3372,6 +3571,10 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -3444,6 +3647,22 @@ packages:
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+
+  /sshpk@1.17.0:
+    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+    dev: false
 
   /stacktrace-parser@0.1.10:
     resolution: {integrity: sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==}
@@ -3650,6 +3869,14 @@ packages:
     dependencies:
       is-number: 7.0.0
 
+  /tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.3.0
+    dev: false
+
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: false
@@ -3683,6 +3910,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.1.3
+    dev: false
+
+  /tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     dev: false
 
   /type-check@0.4.0:
@@ -3780,6 +4017,21 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
+
+  /uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+    dev: false
+
+  /verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
+    dev: false
 
   /viem@1.0.7(typescript@5.1.3):
     resolution: {integrity: sha512-P/T2Zn8+V74kxO2e2NdhNR/MBtldovssigvc36+7g3DgTeETKnSS1fMQdBl0jE+Atlal+M6cuJ2HcFY7U45o0Q==}


### PR DESCRIPTION
This PR switches depcrated n.xyz indexer with the graph's subgraph for global approvals of 721 and 1155 tokens. 