### PR TITLE
Fix optimism bug and make provider calls based on url chainID

### DIFF
--- a/lib/clients/viem.ts
+++ b/lib/clients/viem.ts
@@ -1,14 +1,15 @@
-import { createPublicClient, http } from "viem";
+import { createPublicClient, createWalletClient, http, custom } from "viem";
 import { goerli } from "viem/chains";
-import getViemNetwork from "../utils/getViemNetwork";
+import getViemNetwork from "@/lib/utils/getViemNetwork";
+import { chainIdToViemNetwork } from "@/lib/constants";
 
 const providerEndpoint = process.env.NEXT_PUBLIC_PROVIDER_ENDPOINT || "";
 
-export const getPublicClient = (chainId: number) => {
+export const getPublicClient = (chainId: number, providerEndpoint?: string) => {
   const chain = getViemNetwork(chainId);
   const publicClient = createPublicClient({
     chain: chain,
-    transport: http(),
+    transport: providerEndpoint ? http(providerEndpoint) : http(),
   });
   return publicClient;
 };
@@ -21,3 +22,12 @@ export const rpcClient = createPublicClient({
   chain: goerli,
   transport,
 });
+
+export const getWalletClient = (chainId: number, window: any) => {
+  const walletClient = createWalletClient({
+    chain: chainIdToViemNetwork[chainId],
+    transport: custom(window.ethereum),
+  });
+
+  return walletClient;
+};

--- a/lib/constants/apiKeys.ts
+++ b/lib/constants/apiKeys.ts
@@ -1,2 +1,3 @@
 export const nxyzApiKey = process.env.NEXT_PUBLIC_NXYZ_API_KEY || "";
 export const graphApiKey = process.env.NEXT_PUBLIC_GRAPH_API_KEY || "";
+export const alchemyApiKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY || "";

--- a/lib/constants/chain.ts
+++ b/lib/constants/chain.ts
@@ -1,11 +1,23 @@
+import {
+  goerli,
+  mainnet,
+  optimism,
+  optimismGoerli,
+  polygon,
+  polygonMumbai,
+  sepolia,
+} from "viem/chains";
+import { alchemyApiKey } from "./apiKeys";
+
 export interface ChainIdToUrl {
   [key: number]: string;
 }
 export const chainIdToEtherscanUrl: ChainIdToUrl = {
   1: "https://etherscan.io",
   5: "https://goerli.etherscan.io",
-  10: "https://optimistic.etherscan.io",
   11155111: "https://sepolia.etherscan.io",
+  10: "https://optimistic.etherscan.io",
+  420: "https://goerli-optimism.etherscan.io",
   137: "https://polygonscan.com",
   80001: "https://mumbai.polygonscan.com",
 };
@@ -13,8 +25,29 @@ export const chainIdToEtherscanUrl: ChainIdToUrl = {
 export const chainIdToOpenseaAssetUrl: ChainIdToUrl = {
   1: "https://opensea.io/assets/ethereum",
   5: "https://testnets.opensea.io/assets/goerli",
-  10: "https://opensea.io/assets/optimism",
   11155111: "https://testnets.opensea.io/assets/sepolia",
+  10: "https://opensea.io/assets/optimism",
+  420: "https://opensea.io/assets/optimism-goerli",
   137: "https://opensea.io/assets/matic",
   80001: "https://testnets.opensea.io/assets/mumbai",
+};
+
+export const chainIdToViemNetwork: { [key: number]: any } = {
+  1: mainnet,
+  5: goerli,
+  11155111: sepolia,
+  10: optimism,
+  420: optimismGoerli,
+  137: polygon,
+  80001: polygonMumbai,
+};
+
+export const chainIdToRpcUrl: ChainIdToUrl = {
+  1: `https://eth-mainnet.g.alchemy.com/v2/${alchemyApiKey}`,
+  5: `https://eth-goerli.g.alchemy.com/v2/${alchemyApiKey}`,
+  11155111: `https://eth-sepolia.g.alchemy.com/v2/${alchemyApiKey}`,
+  10: `https://opt-mainnet.g.alchemy.com/v2/${alchemyApiKey}`,
+  420: `https://opt-goerli.g.alchemy.com/v2/${alchemyApiKey}`,
+  137: `https://polygon-mainnet.g.alchemy.com/v2/${alchemyApiKey}`,
+  80001: `https://polygon-mumbai.g.alchemy.com/v2/${alchemyApiKey}`,
 };

--- a/lib/hooks/useGetApprovals.ts
+++ b/lib/hooks/useGetApprovals.ts
@@ -2,7 +2,7 @@ import { OwnedNft } from "alchemy-sdk";
 import { erc721Abi } from "@/lib/abi";
 import { getPublicClient } from "@/lib/clients";
 import useSWR from "swr";
-import { graphApiKey } from "@/lib/constants";
+import { chainIdToRpcUrl, graphApiKey } from "@/lib/constants";
 import request from "graphql-request";
 
 export const useGetApprovals = (ownedNfts: OwnedNft[], owner?: string, chainID = 1) => {
@@ -40,7 +40,8 @@ export async function getApproved(
   chainId: number
 ): Promise<GetApproved> {
   try {
-    const publicClient = getPublicClient(chainId);
+    const providerUrl = chainIdToRpcUrl[chainId];
+    const publicClient = getPublicClient(chainId, providerUrl);
     const response = (await publicClient.readContract({
       address: account as `0x${string}`,
       abi: erc721Abi,

--- a/lib/utils/account.ts
+++ b/lib/utils/account.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { getPublicClient } from "@/lib/clients/viem";
 import { implementationAbi, tokenboundAbi } from "@/lib/abi";
-import { implementationAddress, salt, tokenboundAddress } from "@/lib/constants";
+import { chainIdToRpcUrl, implementationAddress, salt, tokenboundAddress } from "@/lib/constants";
 
 interface GetAccountStatus {
   data?: boolean;
@@ -13,7 +13,8 @@ export async function getAccountStatus(
   account: string
 ): Promise<GetAccountStatus> {
   try {
-    const publicClient = getPublicClient(chainId);
+    const providerUrl = chainIdToRpcUrl[chainId];
+    const publicClient = getPublicClient(chainId, providerUrl);
     const response = (await publicClient.readContract({
       address: account as `0x${string}`,
       abi: implementationAbi,
@@ -50,7 +51,8 @@ export async function getAccount(
   chainId: number
 ): Promise<GetAccount> {
   try {
-    const publicClient = getPublicClient(chainId);
+    const providerUrl = chainIdToRpcUrl[chainId];
+    const publicClient = getPublicClient(chainId, providerUrl);
     const response = (await publicClient.readContract({
       address: tokenboundAddress as `0x${string}`,
       abi: tokenboundAbi,

--- a/lib/utils/getAlchemyNetwork.ts
+++ b/lib/utils/getAlchemyNetwork.ts
@@ -1,12 +1,13 @@
-import { Network } from "alchemy-sdk"
+import { Network } from "alchemy-sdk";
 
 const getAlchemyNetwork = (chainId: number) => {
-    if (chainId == 1) return Network.ETH_MAINNET
-    if (chainId == 137) return Network.MATIC_MAINNET
-    if (chainId == 420) return Network.OPT_MAINNET
-    if (chainId == 5) return Network.ETH_GOERLI
-    if (chainId == 80001) return Network.MATIC_MUMBAI
-    if (chainId == 11155111) return Network.ETH_SEPOLIA
-}
+  if (chainId == 1) return Network.ETH_MAINNET;
+  if (chainId == 137) return Network.MATIC_MAINNET;
+  if (chainId == 10) return Network.OPT_MAINNET;
+  if (chainId == 420) return Network.OPT_GOERLI;
+  if (chainId == 5) return Network.ETH_GOERLI;
+  if (chainId == 80001) return Network.MATIC_MUMBAI;
+  if (chainId == 11155111) return Network.ETH_SEPOLIA;
+};
 
-export default getAlchemyNetwork
+export default getAlchemyNetwork;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^7.55.2",
+    "@tokenbound/sdk": "^0.3.5",
     "@types/node": "20.3.1",
     "@types/react": "18.2.12",
     "@types/react-dom": "18.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@sentry/nextjs':
     specifier: ^7.55.2
     version: 7.55.2(encoding@0.1.13)(next@13.4.5)(react@18.2.0)
+  '@tokenbound/sdk':
+    specifier: ^0.3.5
+    version: 0.3.5(typescript@5.1.3)
   '@types/node':
     specifier: 20.3.1
     version: 20.3.1
@@ -96,6 +99,10 @@ packages:
 
   /@adraffy/ens-normalize@1.9.0:
     resolution: {integrity: sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==}
+    dev: false
+
+  /@adraffy/ens-normalize@1.9.4:
+    resolution: {integrity: sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==}
     dev: false
 
   /@alloc/quick-lru@5.2.0:
@@ -677,8 +684,19 @@ packages:
       '@noble/hashes': 1.3.0
     dev: false
 
+  /@noble/curves@1.2.0:
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+    dev: false
+
   /@noble/hashes@1.3.0:
     resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
+    dev: false
+
+  /@noble/hashes@1.3.2:
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
     dev: false
 
   /@nodelib/fs.scandir@2.1.5:
@@ -752,18 +770,37 @@ packages:
     resolution: {integrity: sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==}
     dev: false
 
+  /@scure/base@1.1.3:
+    resolution: {integrity: sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==}
+    dev: false
+
   /@scure/bip32@1.3.0:
     resolution: {integrity: sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==}
     dependencies:
       '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
-      '@scure/base': 1.1.1
+      '@noble/hashes': 1.3.2
+      '@scure/base': 1.1.3
+    dev: false
+
+  /@scure/bip32@1.3.2:
+    resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
+    dependencies:
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/base': 1.1.3
     dev: false
 
   /@scure/bip39@1.2.0:
     resolution: {integrity: sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==}
     dependencies:
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.2
+      '@scure/base': 1.1.3
+    dev: false
+
+  /@scure/bip39@1.2.1:
+    resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
+    dependencies:
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
     dev: false
 
@@ -924,6 +961,17 @@ packages:
       tslib: 2.5.3
     dev: false
 
+  /@tokenbound/sdk@0.3.5(typescript@5.1.3):
+    resolution: {integrity: sha512-THgeAkY+l/OpUdWsAh/HyP5x9X0pLIyLCSuNPMmmDRUwuSoBC3J65/bZWffX4CXXUXr92IzHrw0PM+Jy7nUBKQ==}
+    dependencies:
+      viem: 1.10.7(typescript@5.1.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
   /@types/estree@1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: false
@@ -960,6 +1008,12 @@ packages:
 
   /@types/scheduler@0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
+    dev: false
+
+  /@types/ws@8.5.5:
+    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
+    dependencies:
+      '@types/node': 20.3.1
     dev: false
 
   /@typescript-eslint/parser@5.59.11(eslint@8.42.0)(typescript@5.1.3):
@@ -1041,6 +1095,20 @@ packages:
       typescript: '>=5.0.4'
       zod: ^3 >=3.19.1
     peerDependenciesMeta:
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.1.3
+    dev: false
+
+  /abitype@0.9.8(typescript@5.1.3):
+    resolution: {integrity: sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      typescript:
+        optional: true
       zod:
         optional: true
     dependencies:
@@ -2743,6 +2811,14 @@ packages:
       ws: 8.12.0
     dev: false
 
+  /isomorphic-ws@5.0.0(ws@8.13.0):
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.13.0
+    dev: false
+
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     dev: false
@@ -4065,6 +4141,30 @@ packages:
       - zod
     dev: false
 
+  /viem@1.10.7(typescript@5.1.3):
+    resolution: {integrity: sha512-yuaYSHgV1g794nfxhn+V89qgK5ziFTLBSNqSDt4KW8YpjLu0Ah6LLZTtpOj3+MRWKKDwJ1YL2rENb8cuXstUzg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.9.4
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
+      '@types/ws': 8.5.5
+      abitype: 0.9.8(typescript@5.1.3)
+      isomorphic-ws: 5.0.0(ws@8.13.0)
+      typescript: 5.1.3
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
   /watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
     engines: {node: '>=10.13.0'}
@@ -4156,6 +4256,19 @@ packages:
 
   /ws@8.12.0:
     resolution: {integrity: sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
+  /ws@8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
There was an issue where OP NFT's were showing the wrong address and not showing the art assets. 

Fix:
- Make alchemy fetch based on chain ID from URL param. This removes the need for the provider_url env
- Add in tokenbound client to handle account fetching and account deployed status